### PR TITLE
Main entrypoint autoload cookie

### DIFF
--- a/spaceline-all-the-icons.el
+++ b/spaceline-all-the-icons.el
@@ -202,6 +202,7 @@
     :face line-face)) '())
 
 ;; Interactive & Setup Functions
+;;;###autoload
 (defun spaceline-all-the-icons-theme ()
   "Set `mode-line-format' to be `spaceline-ml-all-the-icons'."
   (interactive)


### PR DESCRIPTION
When installing from Melpa, it's really convenient to have an autoload
cookie for the main package entry point.

Installation ends up being
```
(package-install spaceline-all-the-icons.el)
```

… and usage:

```
(spaceline-all-the-icons-theme)
```

No need for any require anymore.