### PR TITLE
Ignore projectile-project-root errors

### DIFF
--- a/spaceline-all-the-icons-segments.el
+++ b/spaceline-all-the-icons-segments.el
@@ -500,7 +500,7 @@ doesn't inherit all properties of a face."
     (let* ((name (spaceline-all-the-icons--memoized-file-truename (buffer-file-name)))
 
            (project-root (when spaceline-all-the-icons-projectile-p
-                           (spaceline-all-the-icons--memoized-file-truename (projectile-project-root))))
+                           (spaceline-all-the-icons--memoized-file-truename (ignore-errors (projectile-project-root)))))
 
            (path-relative (or (cadr (split-string name project-root))
                               (replace-regexp-in-string (getenv "HOME") "~" name)))


### PR DESCRIPTION
`(projectile-project-root)` is not an autoloaded function, declaring it forward doesn't make a difference. Even if the entire package is required, when `(projectile-project-root)` can't a project root, it'll raise an error, which results in blowing away the entire mode line. This patch fixes it.