### PR TITLE
Fix failure to load on Emacs 26

### DIFF
--- a/spaceline-all-the-icons-segments.el
+++ b/spaceline-all-the-icons-segments.el
@@ -950,7 +950,7 @@ available updates then restores the current buffer."
 (spaceline-define-segment all-the-icons-battery-status
   "An `all-the-icons' segment to show the battery information"
   (let* ((charging?  (string= "AC" (cdr (assoc ?L fancy-battery-last-status))))
-         (percent    (string-to-int (cdr (assoc ?p fancy-battery-last-status))))
+         (percent    (string-to-number (cdr (assoc ?p fancy-battery-last-status))))
          (time       (cdr (assoc ?t fancy-battery-last-status)))
 
          (icon-alist


### PR DESCRIPTION
`string-to-int` has long been obsolete and is now removed in Emacs 26
which results in the following error and failure to display the modeline

```
Error during redisplay: (eval (spaceline-ml-all-the-icons)) signaled (void-function string-to-int)
```

Replace with `string-to-number` instead.