### PR TITLE
Add mu4e-alert segment.

### DIFF
--- a/spaceline-all-the-icons-segments.el
+++ b/spaceline-all-the-icons-segments.el
@@ -1310,6 +1310,32 @@ INFO should be an object similar to `yahoo-weather-info'."
   :when (and (derived-mode-p 'paradox-menu-mode)
              paradox--current-filter))
 
+;;; mu4e-alert
+(defun all-the-icons-mu4e-alert-modeline-formatter (mail-count)
+  "Mu4e-alert modeline formatter for spaceline-all-the-icons."
+  (when (not (zerop mail-count))
+    (let* ((icon (all-the-icons-faicon "envelope" :v-adjust 0.0)))
+      (propertize
+       (concat
+        (propertize icon
+                    'face `(:height ,(spaceline-all-the-icons--height 0.9) :inherit)
+                    'display '(raise 0.1))
+        (propertize (format " %d" mail-count) 'face `(:height ,(spaceline-all-the-icons--height 0.9) :inherit) 'display '(raise 0.1)))
+       'help-echo (concat (if (= mail-count 1)
+                              "You have an unread email"
+                            (format "You have %s unread emails" mail-count))
+                          "\nClick here to view "
+                          (if (= mail-count 1) "it" "them"))
+       'mouse-face (spaceline-all-the-icons--highlight)
+       'local-map (make-mode-line-mouse-map 'mouse-1 'mu4e-alert-view-unread-mails)))))
+
+(spaceline-define-segment all-the-icons-mu4e-alert
+  "An `all-the-icons' segment to display unread mail count using mu4e-alert"
+  (when (and active (featurep 'mu4e-alert))
+    (progn
+      (setq mu4e-alert-modeline-formatter 'all-the-icons-mu4e-alert-modeline-formatter)
+      mu4e-alert-mode-line)))
+
 (defmacro define-spaceline-all-the-icons--paradox-segment (type icon mouse &rest body)
   "Macro to declare `spaceline' segment for paradox information of TYPE.
 ICON should be an `all-the-icons' icon to display before the segment.

--- a/spaceline-all-the-icons.el
+++ b/spaceline-all-the-icons.el
@@ -69,6 +69,7 @@
 ;; - `sunset' [`yahoo-weather']                        Display an icon to show todays sunset time
 ;; - `battery-status' [`fancy-battery']                Display a colour coded battery with time remaining
 ;; - `nyan-mode' [`nyan-mode']                         Display Nyan Cat as a progress meter through the buffer
+;; - `mu4e-alert' [`mu4e-alert']                       Display an icon with unread mail count
 
 ;;; Code:
 
@@ -191,7 +192,7 @@ Add ADDITIONAL-SEGMENTS to the end of the theme."
       :when (or (and (bound-and-true-p nyan-mode)
                      spaceline-all-the-icons-nyan-cat-p)
                 spaceline-all-the-icons-minor-modes-p))
-     
+
      ((all-the-icons-separator-minor-mode-left
        all-the-icons-minor-modes
        all-the-icons-separator-minor-mode-right)
@@ -209,7 +210,8 @@ Add ADDITIONAL-SEGMENTS to the end of the theme."
      ((all-the-icons-weather
        all-the-icons-temperature
        all-the-icons-sunrise
-       all-the-icons-sunset)
+       all-the-icons-sunset
+       all-the-icons-mu4e-alert)
       :face powerline-active2
       :separator (spaceline-all-the-icons--separator spaceline-all-the-icons-secondary-separator " "))
 


### PR DESCRIPTION
This adds the mu4e-alert unread emails badge into the modeline. It is added to the same group where the yahoo-weather ones are so that it is nicely grouped together and separated from the weather icons.