### PR TITLE
Scaling is done by custom var instead of `powerline-text-scale-factor`

### DIFF
--- a/spaceline-all-the-icons.el
+++ b/spaceline-all-the-icons.el
@@ -105,11 +105,16 @@
   :group 'spaceline-all-the-icons
   :type 'string)
 
+(defcustom spaceline-scale-factor nil
+ "Scale of mode-line font height."
+ :group 'spaceline-all-the-icons
+ :type '(choice float integer (const nil)))
+
 ;;; Global helper functions
 (defun spaceline-all-the-icons--height (&optional height)
-  "Scale `powerline-text-scale-factor' by HEIGHT."
-  (if (bound-and-true-p powerline-text-scale-factor)
-      (* (or height 1) (or powerline-text-scale-factor 1))
+  "Scale `spaceline-scale-factor' by HEIGHT."
+  (if (bound-and-true-p spaceline-scale-factor)
+      (* (or height 1) (or spaceline-scale-factor 1))
       (or height 1)))
 
 (defun spaceline-all-the-icons--face-background (face)


### PR DESCRIPTION
Hi!
Using `powerline-text-scale-factor` for scaling is nice hack, but unfortunately when setting it less than 1, it forces spaceline to be truncated like so:
![2](https://user-images.githubusercontent.com/160056/60256790-e3950f00-98da-11e9-93a1-2659f1039f11.png)

This PR does scaling by dedicated custom var `spaceline-scale-factor` instead of `powerline-text-scale-factor`. I've tested it in my setup and it works perfect.
I'm not that much of a ELisp hacker myself, so any feedback is appreciated.
